### PR TITLE
Fix package.json JSON formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,7 @@
     "eslint-plugin-react-refresh": "^0.4.18",
     "globals": "^15.14.0",
     "vite": "^6.1.0",
-
-    "sharp": "^0.33.5"
-
+    "sharp": "^0.33.5",
     "vite-imagetools": "^8.0.0"
-
   }
 }


### PR DESCRIPTION
## Summary
- add the missing comma in devDependencies so package.json is valid JSON again

## Testing
- npm run lint *(fails: existing ESLint parsing errors in BottomSection.jsx, Header.jsx, ContactPage.jsx, HomePage.jsx, ReviewsPage.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cf59308de8833280c76f370d8261f8