### PR TITLE
Improve SEO metadata handling and add sitemap/robots

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://private-swimming-lessons.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://private-swimming-lessons.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://private-swimming-lessons.com/reviews</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://private-swimming-lessons.com/videos</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://private-swimming-lessons.com/contact</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+</urlset>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,10 +6,12 @@ import Footer from './Components/Footer/Footer'
 import ContactPage from './Pages/ContactPage/ContactPage'
 import ReviewsPage from './Pages/ReviewsPage/ReviewsPage'
 import VideosPage from './Pages/VideosPage/VideosPage'
+import SeoManager from './Components/SeoManager'
 
 function App() {
   return (
     <BrowserRouter>
+      <SeoManager />
       <Header />
       <Routes>
         <Route path='/' element={<HomePage />} />

--- a/src/Components/SeoManager.jsx
+++ b/src/Components/SeoManager.jsx
@@ -1,0 +1,89 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+const siteUrl = 'https://private-swimming-lessons.com'
+const defaultImage = `${siteUrl}/images/private-swimming-lessons-instructors-preview.jpg`
+
+const seoByPath = {
+  '/': {
+    title: 'Confidence-Building Private Swimming Lessons in Northeast Georgia | Christin Mitchell',
+    description:
+      'Book personalized private swimming lessons with Christin Mitchell in Northeast Georgia. Patient instruction for infants, kids, and adults who want to conquer fear, improve technique, and feel confident in the water.',
+  },
+  '/reviews': {
+    title: 'Private Swimming Lesson Reviews in Northeast Georgia | Christin Mitchell',
+    description:
+      'Read real private swimming lesson reviews from families and adult swimmers across Northeast Georgia. See how Christin Mitchell helps swimmers conquer fear and gain confidence.',
+  },
+  '/videos': {
+    title: 'Private Swim Lesson Videos | Christin Mitchell Northeast Georgia',
+    description:
+      'Watch private swim lesson videos featuring kids and adults building water confidence and stroke skills with Christin Mitchell in Northeast Georgia.',
+  },
+  '/contact': {
+    title: 'Contact Christin Mitchell for Private Swim Lessons | Northeast Georgia',
+    description:
+      'Contact Christin Mitchell to ask questions and schedule private swim lessons in Northeast Georgia for infants, kids, teens, and adults.',
+  },
+}
+
+const ensureMeta = (selector, attribute, value) => {
+  let element = document.head.querySelector(selector)
+
+  if (!element) {
+    element = document.createElement('meta')
+    element.setAttribute(attribute, value)
+    document.head.appendChild(element)
+  }
+
+  return element
+}
+
+const SeoManager = () => {
+  const location = useLocation()
+
+  useEffect(() => {
+    const current = seoByPath[location.pathname] ?? seoByPath['/']
+    const canonicalUrl = location.pathname === '/' ? siteUrl : `${siteUrl}${location.pathname}`
+
+    document.title = current.title
+
+    const descriptionMeta = ensureMeta('meta[name="description"]', 'name', 'description')
+    descriptionMeta.setAttribute('content', current.description)
+
+    const robotsMeta = ensureMeta('meta[name="robots"]', 'name', 'robots')
+    robotsMeta.setAttribute('content', 'index, follow')
+
+    let canonicalLink = document.head.querySelector('link[rel="canonical"]')
+    if (!canonicalLink) {
+      canonicalLink = document.createElement('link')
+      canonicalLink.setAttribute('rel', 'canonical')
+      document.head.appendChild(canonicalLink)
+    }
+    canonicalLink.setAttribute('href', canonicalUrl)
+
+    const ogTitle = ensureMeta('meta[property="og:title"]', 'property', 'og:title')
+    const ogDescription = ensureMeta('meta[property="og:description"]', 'property', 'og:description')
+    const ogUrl = ensureMeta('meta[property="og:url"]', 'property', 'og:url')
+    const ogType = ensureMeta('meta[property="og:type"]', 'property', 'og:type')
+    const ogImage = ensureMeta('meta[property="og:image"]', 'property', 'og:image')
+
+    ogTitle.setAttribute('content', current.title)
+    ogDescription.setAttribute('content', current.description)
+    ogUrl.setAttribute('content', canonicalUrl)
+    ogType.setAttribute('content', 'website')
+    ogImage.setAttribute('content', defaultImage)
+
+    const twitterTitle = ensureMeta('meta[name="twitter:title"]', 'name', 'twitter:title')
+    const twitterDescription = ensureMeta('meta[name="twitter:description"]', 'name', 'twitter:description')
+    const twitterImage = ensureMeta('meta[name="twitter:image"]', 'name', 'twitter:image')
+
+    twitterTitle.setAttribute('content', current.title)
+    twitterDescription.setAttribute('content', current.description)
+    twitterImage.setAttribute('content', defaultImage)
+  }, [location.pathname])
+
+  return null
+}
+
+export default SeoManager

--- a/src/Pages/VideosPage/VideosPage.jsx
+++ b/src/Pages/VideosPage/VideosPage.jsx
@@ -2,10 +2,22 @@ import BottomSection from '../../Components/BottomSection'
 import './VideosPage.css'
 
 const videos = [
-  'https://www.facebook.com/plugins/video.php?href=https://www.facebook.com/professionalprivatelearning/videos/932123924777574&mute=1',
-  'https://www.facebook.com/plugins/video.php?href=https://www.facebook.com/Kreal514/videos/10211548753146306&mute=1',
-  'https://www.facebook.com/plugins/video.php?href=https://www.facebook.com/1511873867/videos/pcb.10221956214403759/1318941162077501&mute=1',
-  'https://www.facebook.com/plugins/video.php?href=https://www.facebook.com/professionalprivatelearning/videos/1885181455168360&mute=1',
+  {
+    src: 'https://www.facebook.com/plugins/video.php?href=https://www.facebook.com/professionalprivatelearning/videos/932123924777574&mute=1',
+    title: 'Student breakthrough during private swimming lesson video 1',
+  },
+  {
+    src: 'https://www.facebook.com/plugins/video.php?href=https://www.facebook.com/Kreal514/videos/10211548753146306&mute=1',
+    title: 'Student breakthrough during private swimming lesson video 2',
+  },
+  {
+    src: 'https://www.facebook.com/plugins/video.php?href=https://www.facebook.com/1511873867/videos/pcb.10221956214403759/1318941162077501&mute=1',
+    title: 'Student breakthrough during private swimming lesson video 3',
+  },
+  {
+    src: 'https://www.facebook.com/plugins/video.php?href=https://www.facebook.com/professionalprivatelearning/videos/1885181455168360&mute=1',
+    title: 'Student breakthrough during private swimming lesson video 4',
+  },
 ]
 
 const VideosPage = () => {
@@ -19,7 +31,7 @@ const VideosPage = () => {
         </header>
 
         <div className='videos-grid'>
-          {videos.map((src) => (
+          {videos.map(({ src, title }) => (
             <div className='video-card card' key={src}>
               <iframe
                 src={src}
@@ -31,7 +43,7 @@ const VideosPage = () => {
                 allow='autoplay; clipboard-write; encrypted-media; picture-in-picture'
                 allowFullScreen
                 loading='lazy'
-                title={src}
+                title={title}
               ></iframe>
             </div>
           ))}


### PR DESCRIPTION
### Motivation
- Ensure each route has appropriate title, meta description, canonical, Open Graph, and Twitter metadata so pages share unique SEO/social preview information instead of only the homepage meta.
- Provide crawl discovery and indexing hints to search engines by adding a sitemap and robots file.
- Improve accessibility and semantics of embedded videos by giving iframes descriptive `title` attributes.

### Description
- Added `src/Components/SeoManager.jsx`, a route-aware component that updates `document.title`, `meta[name="description"]`, `link[rel="canonical"]`, Open Graph, and Twitter meta tags on navigation and creates tags if missing.
- Mounted `SeoManager` at the app level in `src/App.jsx` so metadata updates automatically when routes change.
- Replaced URL-based iframe `title` values with descriptive titles in `src/Pages/VideosPage/VideosPage.jsx` for better semantics and accessibility.
- Added static crawl files `public/sitemap.xml` (listing `/`, `/reviews`, `/videos`, `/contact`) and `public/robots.txt` (allows crawling and references the sitemap) so the production build includes them.

### Testing
- Ran `npm run lint` and it completed successfully (no blocking lint errors).
- Ran `npm run build` and the production build completed successfully; build output was generated under `dist` (non-blocking warnings about `http-proxy` env and missing source images for `images:generate` were observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca425ba470833297907130d81a5965)